### PR TITLE
PointLightの時の初期値を修正

### DIFF
--- a/jp.iridescenet.stagelightmaneuver/Runtime/Channels/LightChannel.cs
+++ b/jp.iridescenet.stagelightmaneuver/Runtime/Channels/LightChannel.cs
@@ -270,7 +270,16 @@ namespace StageLightManeuver
                     }
                     else
                     {
-                        hdAdditionalLightData.SetCookie( Texture2D.whiteTexture);
+                        if (light.type == LightType.Point)
+                        {
+                            // SetCookieの処理がNULLを想定してないが初期値はNULLの為、直接設定
+                            // ※hdAdditionalLightData.SetCookieも、セットしているだけ（HDRP 14.0.8、17.0.8で確認）
+                            light.cookie = null;
+                        }
+                        else
+                        {
+                            hdAdditionalLightData.SetCookie( Texture2D.whiteTexture);
+                        }
                     }
                     // hdAdditionalLightData.UpdateAllLightValues();
                     // hdAdditionalLightData.setli


### PR DESCRIPTION
### エラー内容
PointLightでcookieのテクスチャを未設定の場合、下記のエラーが発生する
Texture dimension Tex2D is not supported for point lights.

### 対応
- Cubemapを設定しないといけないところを、Texture2D.whiteTextureを設定してたので、NULLを設定するように修正

### 懸念
hdAdditionalLightData.SetCookieが引数にNULLを想定していないので、lightのcookieに直接NULLを設定している ※HDRP 14.0.8、17.0.8で確認