### PR TITLE
fix: レイヤーミキサのプロパティの更新挙動を加算から上書きに変更

### DIFF
--- a/jp.iridescenet.stagelightmaneuver/Runtime/StageLightTimeline/StageLightTimelineLayerMixerBehaviour.cs
+++ b/jp.iridescenet.stagelightmaneuver/Runtime/StageLightTimeline/StageLightTimelineLayerMixerBehaviour.cs
@@ -8,21 +8,26 @@ namespace StageLightManeuver
 {
     public class StageLightTimelineLayerMixerBehaviour : PlayableBehaviour
     {
-        
+
         public List<TimelineClip> clips;
 
         public StageLightTimelineTrack stageLightTimelineTrack;
 
         public StageLightFixtureBase trackBinding;
 
-        private List<string> overwriteExceptionPropNames = new List<string>() {"Clock","StageLight Order"};
+        private static readonly HashSet<string> overwriteExceptionPropNames = new()
+        {
+            "Clock",
+            "StageLight Order"
+        };
 
         private List<StageLightQueueData> composedQueueDatas;
-        private List<string> alreadyAddedPropNames = new();
+        private HashSet<string> alreadyAddedPropNames = new();
+        private List<StageLightQueueData> QueueDatas => composedQueueDatas;
 
         public override void ProcessFrame(Playable playable, FrameData info, object playerData)
         {
-            
+
             trackBinding = playerData as StageLightFixtureBase;
             var hasAnyClipPlaying = false;
             var time = playable.GetTime();
@@ -37,19 +42,38 @@ namespace StageLightManeuver
             for (int i = 0; i < inputCount; i++)
             {
                 var input = playable.GetInput(inputCount - 1 - i);
-                var trackMixer = ((ScriptPlayable<StageLightTimelineMixerBehaviour>) input).GetBehaviour();
+                var trackMixer = ((ScriptPlayable<StageLightTimelineMixerBehaviour>)input).GetBehaviour();
                 var queueDatas = trackMixer.QueueDatas;
                 alreadyAddedPropNames.Clear();
                 foreach (var queueData in composedQueueDatas)
                 {
-                    foreach (var propName in queueData.stageLightProperties.Where(x => x.propertyOverride).Select(x => x.propertyName))
+                    foreach (var propName in queueData.stageLightProperties.Where(x => x.propertyOverride)
+                                .Select(x => x.propertyName))
                     {
-                        if(!overwriteExceptionPropNames.Contains(propName))
+                        if (!overwriteExceptionPropNames.Contains(propName))
                             alreadyAddedPropNames.Add(propName);
                     }
                 }
 
-                foreach (var queueData in queueDatas) composedQueueDatas.Add(queueData);
+                foreach (var q in queueDatas)
+                {
+                    // 重複しているプロパティを削除
+                    var j = 0;
+                    while (q.stageLightProperties.Count > j)
+                    {
+                        var prop = q.stageLightProperties[j];
+                        if (alreadyAddedPropNames.Contains(prop.propertyName))
+                        {
+                            q.stageLightProperties.RemoveAt(j);
+                        }
+                        else
+                        {
+                            j++;
+                        }
+                    }
+                }
+
+                composedQueueDatas.AddRange(queueDatas);
             }
 
             for (int i = 0; i < composedQueueDatas.Count; i++)
@@ -57,7 +81,7 @@ namespace StageLightManeuver
                 trackBinding.AddQue(composedQueueDatas[composedQueueDatas.Count - 1 - i]);
                 hasAnyClipPlaying = true;
             }
-            
+
             if (stageLightTimelineTrack)
             {
                 if (!hasAnyClipPlaying)


### PR DESCRIPTION
#48 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate property handling in stage light timeline queues, preventing unintended overrides and ensuring consistent timeline application (including out-of-clip update behavior).

* **Performance Improvements**
  * Optimized queue processing and property lookups for faster, more efficient timeline merging and playback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->